### PR TITLE
Matching nodes in union types

### DIFF
--- a/src/SmaCC_GLR_Runtime/SmaCCGLRParser.class.st
+++ b/src/SmaCC_GLR_Runtime/SmaCCGLRParser.class.st
@@ -470,8 +470,9 @@ SmaCCGLRParser >> splitForPatternToken [
 						or:
 							[ each notNil
 								and:
-									[ (self class environment at: each ifAbsent: [ Object ])
-										includesBehavior: nodeClass ] ])
+									[ ((self class environment at: each ifAbsent: [ Object ])
+includesBehavior: nodeClass) or: [ nodeClass includesBehavior: (self
+class environment at: each ifAbsent: [ self class ]) ] ] ])
 						ifTrue:
 							[ self addActionsFor: i to: actions.
 							actions


### PR DESCRIPTION
Fixes an issue with nodes not being properly matched when they belonged to a union type.