### PR TITLE
add a group to load the Source Editing

### DIFF
--- a/src/BaselineOfSmaCC/BaselineOfSmaCC.class.st
+++ b/src/BaselineOfSmaCC/BaselineOfSmaCC.class.st
@@ -44,7 +44,8 @@ BaselineOfSmaCC >> baseline: spec [
 				group: 'C#' with: #('SmaCC_CSharp');
 				group: 'Delphi' with: #('SmaCC_Delphi' 'SmaCC_Delphi_Forms');
 				group: 'Java' with: #('SmaCC_Java');
-				group: 'Javascript' with: #('SmaCC_Javascript_Parser') ].
+				group: 'Javascript' with: #('SmaCC_Javascript_Parser');
+				group: 'withSource' with: #('SmaCC_Source_Editing')].
 	spec
 		for: #pharo
 		do: [ spec


### PR DESCRIPTION
fix #11 

In case we need the source when we parse, we weed to load the package SmaCC_Source_Editing

I added in the baseline a group so we can load both a language parser and the source

example

```st
spec
		baseline: 'SmaCC'
		with: [ spec
				loads: #('Java' 'withSource');
				repository: 'github://j-brant/SmaCC:master/src' ].
```