### PR TITLE
Refactor code to SmaCCMethodNodeSourceIntervalFinder

### DIFF
--- a/src/SmaCC_Rewrite_Engine_UI/SmaCCMethodNodeSourceIntervalFinder.class.st
+++ b/src/SmaCC_Rewrite_Engine_UI/SmaCCMethodNodeSourceIntervalFinder.class.st
@@ -8,7 +8,7 @@ Class {
 		'sourceNode',
 		'sourceInterval'
 	],
-	#category : #'SmaCC_Rewrite_Engine_UI-Context'
+	#category : #'SmaCC_Rewrite_Engine_UI'
 }
 
 { #category : #finding }

--- a/src/SmaCC_Rewrite_Engine_UI/SmaCCMethodNodeSourceIntervalFinder.class.st
+++ b/src/SmaCC_Rewrite_Engine_UI/SmaCCMethodNodeSourceIntervalFinder.class.st
@@ -1,0 +1,79 @@
+Class {
+	#name : #SmaCCMethodNodeSourceIntervalFinder,
+	#superclass : #Object,
+	#instVars : [
+		'methodNode',
+		'sourceString',
+		'sourceAst',
+		'sourceNode',
+		'sourceInterval'
+	],
+	#category : #'SmaCC_Rewrite_Engine_UI-Context'
+}
+
+{ #category : #finding }
+SmaCCMethodNodeSourceIntervalFinder >> equivalentNodeTo: aNode in: otherTree [
+	"Taken from GtSmaCCTransformationToolkitDebuggerElement>>#equivalentNodeTo:in:"
+
+	| equivParent nodeIndex equivNode |
+	aNode isMethod ifTrue: [ ^ otherTree ].
+	(aNode parent isReturn and: [ aNode parent parent parent isMethod ])
+		ifTrue: [ equivNode := otherTree isSequence
+					ifTrue: [ otherTree statements last ]
+					ifFalse: [ otherTree ].
+			^ equivNode isReturn ifTrue: [ equivNode value ] ifFalse: [ equivNode ] ].
+	aNode parent isMethod
+		ifTrue: [ otherTree isSequence ifTrue: [ ^ otherTree ] ifFalse: [ ^ otherTree parent ] ].
+	equivParent := self equivalentNodeTo: aNode parent in: otherTree.
+	equivParent ifNil: [ ^ nil ].
+	nodeIndex := aNode parent children identityIndexOf: aNode.
+	^ equivParent children at: nodeIndex ifAbsent: [ nil ]
+]
+
+{ #category : #finding }
+SmaCCMethodNodeSourceIntervalFinder >> find [
+	"Adopted from GtSmaCCTransformationToolkitDebuggerElement>>#intervalFromMethodNode:inSource:"
+
+	<return: #Interval>
+	sourceAst := RBParser
+			parseExpression: sourceString
+			onError: [ :msg :pos | ^ sourceInterval := 1 to: 0 ].
+	sourceNode := self equivalentNodeTo: methodNode in: sourceAst.
+	sourceNode ifNil: [ ^ sourceInterval := 1 to: 0 ].
+	^ sourceInterval := sourceNode start to: sourceNode stop
+]
+
+{ #category : #accessing }
+SmaCCMethodNodeSourceIntervalFinder >> methodNode [
+	^ methodNode
+]
+
+{ #category : #accessing }
+SmaCCMethodNodeSourceIntervalFinder >> methodNode: anObject [
+	methodNode := anObject
+]
+
+{ #category : #'accessing - computed' }
+SmaCCMethodNodeSourceIntervalFinder >> sourceAst [
+	^ sourceAst
+]
+
+{ #category : #'accessing - computed' }
+SmaCCMethodNodeSourceIntervalFinder >> sourceInterval [
+	^ sourceInterval
+]
+
+{ #category : #'accessing - computed' }
+SmaCCMethodNodeSourceIntervalFinder >> sourceNode [
+	^ sourceNode
+]
+
+{ #category : #accessing }
+SmaCCMethodNodeSourceIntervalFinder >> sourceString [
+	^ sourceString
+]
+
+{ #category : #accessing }
+SmaCCMethodNodeSourceIntervalFinder >> sourceString: anObject [
+	sourceString := anObject
+]

--- a/src/SmaCC_Rewrite_Engine_UI/SmaCCMethodNodeSourceIntervalFinder.class.st
+++ b/src/SmaCC_Rewrite_Engine_UI/SmaCCMethodNodeSourceIntervalFinder.class.st
@@ -13,8 +13,6 @@ Class {
 
 { #category : #finding }
 SmaCCMethodNodeSourceIntervalFinder >> equivalentNodeTo: aNode in: otherTree [
-	"Taken from GtSmaCCTransformationToolkitDebuggerElement>>#equivalentNodeTo:in:"
-
 	| equivParent nodeIndex equivNode |
 	aNode isMethod ifTrue: [ ^ otherTree ].
 	(aNode parent isReturn and: [ aNode parent parent parent isMethod ])
@@ -32,8 +30,6 @@ SmaCCMethodNodeSourceIntervalFinder >> equivalentNodeTo: aNode in: otherTree [
 
 { #category : #finding }
 SmaCCMethodNodeSourceIntervalFinder >> find [
-	"Adopted from GtSmaCCTransformationToolkitDebuggerElement>>#intervalFromMethodNode:inSource:"
-
 	<return: #Interval>
 	sourceAst := RBParser
 			parseExpression: sourceString

--- a/src/SmaCC_Rewrite_Engine_UI/SmaCCTransformationToolkitDebugSession.class.st
+++ b/src/SmaCC_Rewrite_Engine_UI/SmaCCTransformationToolkitDebugSession.class.st
@@ -71,27 +71,11 @@ SmaCCTransformationToolkitDebugSession >> currentRewriteContext [
 ]
 
 { #category : #private }
-SmaCCTransformationToolkitDebugSession >> equivalentNodeTo: aNode in: otherTree [
-	| equivParent nodeIndex equivNode |
-	aNode isMethod ifTrue: [ ^ otherTree ].
-	(aNode parent isReturn and: [ aNode parent parent parent isMethod ])
-		ifTrue:
-			[ equivNode := otherTree isSequence ifTrue: [ otherTree statements last ] ifFalse: [ otherTree ].
-			^ equivNode isReturn ifTrue: [ equivNode value ] ifFalse: [ equivNode ] ].
-	aNode parent isMethod ifTrue: [ otherTree isSequence ifTrue: [ ^ otherTree ] ifFalse: [ ^ otherTree parent ] ].
-	equivParent := self equivalentNodeTo: aNode parent in: otherTree.
-	equivParent ifNil: [ ^ nil ].
-	nodeIndex := aNode parent children identityIndexOf: aNode.
-	^ equivParent children at: nodeIndex ifAbsent: [ nil ]
-]
-
-{ #category : #private }
 SmaCCTransformationToolkitDebugSession >> intervalFromMethodNode: aNode inSource: aString [
-	| otherTree otherNode |
-	otherTree := RBParser parseExpression: aString onError: [ :msg :pos | ^ 1 to: 0 ].
-	otherNode := self equivalentNodeTo: aNode in: otherTree.
-	otherNode ifNil: [ ^ 1 to: 0 ].
-	^ otherNode start to: otherNode stop
+	^ SmaCCMethodNodeSourceIntervalFinder new
+		methodNode: aNode;
+		sourceString: aString;
+		find
 ]
 
 { #category : #testing }


### PR DESCRIPTION
The purpose of this pull request is to refactor `SmaCCTransformationToolkitDebugSession>>#intervalFromMethodNode:inSource:` to a dedicated class called `SmaCCMethodNodeSourceIntervalFinder`. 

The same logic is also implemented in `GtSmaCCTransformationToolkitDebuggerElement>>#intervalFromMethodNode:inSource:` (in `gt4smacc`) and I need the same logic in GToolkit debugger/coder.