### PR TITLE
Make the parser table generation deterministic

### DIFF
--- a/src/SmaCC_Development/SmaCCLR1Item.class.st
+++ b/src/SmaCC_Development/SmaCCLR1Item.class.st
@@ -59,8 +59,9 @@ SmaCCLR1Item >> grammar [
 
 { #category : 'comparing' }
 SmaCCLR1Item >> hash [
-	^ (self symbol identityHash hashMultiply bitXor: location)
-		hashMultiply bitXor: rhs identityHash
+	"Stable hash, not identityHash."
+	^ (self symbol hash hashMultiply bitXor: location)
+		hashMultiply bitXor: rhs hash
 ]
 
 { #category : 'accessing' }

--- a/src/SmaCC_Development/SmaCCSymbol.class.st
+++ b/src/SmaCC_Development/SmaCCSymbol.class.st
@@ -110,6 +110,12 @@ SmaCCSymbol >> firstTerminals [
 	^ firstTerminals
 ]
 
+{ #category : 'comparing' }
+SmaCCSymbol >> hash [
+	"Content-based hash for reproducible LR generation."
+	^ name ifNil: [ super hash ] ifNotNil: [ name hash ]
+]
+
 { #category : 'initialize-release' }
 SmaCCSymbol >> initialize [
 	super initialize.


### PR DESCRIPTION
I hope this patch is useful for you, the Elixir grammar runs into these issues. I am planning on fixing the grammar so it doesn't exhibit this, but this patch should be useful regardless.

Currently how the table disambiguates tables is by an identity hash which is non deterministic

Here is a minimal grammar that reproduces this

```bnf
%root start;
%start start;
%prefix Mini;
%suffix Node;

start
    : foo
    | bar
    ;

foo : <a> ;
bar : <a> ;

<a> : a ;
```

Putting this into MiniParser has this bit of smalltalk code fail

```st
def := MiniParser parserDefinitionString.
MiniParser compileGrammar: def.
t1 := MiniParser transitionTable copy.
r1 := MiniParser reduceTable copy.
MiniParser compileGrammar: def.
t2 := MiniParser transitionTable copy.
r2 := MiniParser reduceTable copy.
{'transitionTable equal:' -> (t1 = t2).
	'reduceTable equal:' -> (r1 = r2)}
```

It will sometimes return true sometimes return false for reduceTable equal

the elixir grammar exhibits this via the following

```bnf
%root start;
%start start;
%prefix Mini;
%suffix Node;

%left <op>;

start : expr ;

expr
    : expr op_expr        "chain rule, no terminal in RHS"
    | <num>
    ;

op_expr
    : <op> expr
    ;

<num> : [0-9]+ ;
<op>  : \+ ;
```