### PR TITLE
Resolve reduce-reduce conflicts by rule precedence

### DIFF
--- a/src/SmaCC_Development/SmaCCAmbiguousAction.class.st
+++ b/src/SmaCC_Development/SmaCCAmbiguousAction.class.st
@@ -47,7 +47,15 @@ SmaCCAmbiguousAction >> preferredAction [
 
 { #category : 'accessing' }
 SmaCCAmbiguousAction >> sortedActions [
-	"When in doubt shift the token"
+	"For reduce-reduce ties, prefer higher-precedence rule (yacc-style).
+	 The default tie-break by id is unchanged for shift-reduce. Closes the
+	 gap where SmaCCShiftAction>>mergeWithReduceAction:prefer: resolves
+	 shift-reduce by precedence, but the complementary reduce-reduce path
+	 in SmaCCReduceAction>>mergeWithReduceAction: just bundles into a
+	 SmaCCAmbiguousAction without consulting precedence."
 
-	^ actions asSortedCollection: [ :a :b | a id <= b id ]
+	^ actions asSortedCollection: [ :a :b |
+		a id = b id
+			ifTrue: [ (a precedence ifNil: [ -1 ]) >= (b precedence ifNil: [ -1 ]) ]
+			ifFalse: [ a id < b id ] ]
 ]


### PR DESCRIPTION
This patch allows `SmaCCReduceAction >> mergeWithReduceAction:` to have similar machinery to `SmaCCShiftAction>>mergeWithReduceAction:prefer:`. It does this through `SmaCCAmbigiousAction >> sortedActions`.Meaning that that we can break reduce-reduce ties in the same way we have in the shift-reduce case [that is documented](https://books.pharo.org/booklet-Smacc/html/Chapters/Smacc/SmaccDirectives.html#precedence%20rules).

Concrete case: the Elixir grammar has
```ebnf
  matched_expr   : ... | <at_op> 'op' matched_expr
  unmatched_expr : ... | <at_op> 'op' expr
```
Both reduce to *_expr from <at_op> + arg. With matched_expr's rule having at_op precedence and unmatched_expr's chain via expr having -1 (no terminals), the matched-prefix should win. With id-based tie-break it depends on declaration order. With this patch, precedence wins consistently, so `case x do @attr -> body end` parses correctly.

Let me know if this case is already covered and we are just over complicating it